### PR TITLE
Remove footer links and open source section

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -111,23 +111,6 @@ const Footer: React.FC = () => {
                   <Link
                     href={link.href}
                     className="text-gray-300 hover:text-white transition-colors duration-200"
-                  >
-                    {link.name}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </div>
-
-          {/* Open Source Links */}
-          <div>
-            <h3 className="font-semibold text-white mb-4">Open Source</h3>
-            <ul className="space-y-2">
-              {footerLinks.opensource.map((link) => (
-                <li key={link.name}>
-                  <Link
-                    href={link.href}
-                    className="text-gray-300 hover:text-white transition-colors duration-200"
                     target="_blank"
                     rel="noopener noreferrer"
                   >


### PR DESCRIPTION
Removed the rendering of footer links and open source section. 
git commit -m "fix(footer): remove duplicate open source section (#25)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Open Source links in the footer now open in a new tab for improved user experience and include security protections.

* **Chores**
  * Consolidated the footer's Open Source section structure for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->