### PR TITLE
Update Footer repository link to main Opsimate Repo

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -15,17 +15,17 @@ const Footer: React.FC = () => {
       { name: 'Documentation', href: 'https://opsimate.vercel.app/#integrations' }, // Placeholder - will link to actual docs
     ],
     opensource: [
-      { name: 'GitHub Repository', href: 'https://github.com/Fifaboyz/OpsiMate' },
-      { name: 'Contribute', href: 'https://github.com/Fifaboyz/OpsiMate/blob/main/CONTRIBUTING.md' },
-      { name: 'Issues', href: 'https://github.com/Fifaboyz/OpsiMate/issues' },
-      { name: 'License', href: 'https://github.com/Fifaboyz/OpsiMate/blob/main/LICENSE' },
+      { name: 'GitHub Repository', href: 'https://github.com/OpsiMate/OpsiMate' },
+      { name: 'Contribute', href: 'https://github.com/OpsiMate/OpsiMate/blob/main/CONTRIBUTING.md' },
+      { name: 'Issues', href: 'https://github.com/OpsiMate/OpsiMate/issues' },
+      { name: 'License', href: 'https://github.com/OpsiMate/OpsiMate/blob/main/LICENSE' },
     ],
   };
 
   const socialLinks = [
     { 
       name: 'GitHub', 
-      href: 'https://github.com/Fifaboyz/OpsiMate', // From documentation
+      href: 'https://github.com/OpsiMate/OpsiMate', // From documentation
       icon: Github 
     },
     { 

--- a/package-lock.json
+++ b/package-lock.json
@@ -563,6 +563,7 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1032,6 +1033,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1462,6 +1464,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2114,6 +2117,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2282,6 +2286,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3948,6 +3953,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.30.tgz",
       "integrity": "sha512-+COdu6HQrHHFQ1S/8BBsCag61jZacmvbuL2avHvQFbWa2Ox7bE+d8FyNgxRLjXQ5wtPyQwEmk85js/AuaG2Sbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.30",
         "@swc/helpers": "0.5.5",
@@ -4412,6 +4418,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4564,6 +4571,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4576,6 +4584,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5531,6 +5540,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5700,6 +5710,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
**Summary:**
Updated the GitHub repository link in the footer to point to the main OpsiMate repository.

**Changes Made:**
Footer GitHub Repository link updated from https://github.com/Fifaboyz/OpsiMate → https://github.com/OpsiMate/OpsiMate.

**Screenshot**
<img width="781" height="653" alt="image" src="https://github.com/user-attachments/assets/fcbe6294-0e09-4247-9a23-53efcd4ccccc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository links in the footer to point to the new OpsiMate repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->