### PR TITLE
[FEAT] Optimized Integration section for mobile view

### DIFF
--- a/components/IntegrationsSection.tsx
+++ b/components/IntegrationsSection.tsx
@@ -278,7 +278,7 @@ const IntegrationsSection: React.FC = () => {
         </div>
 
         {/* Integrations Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6 mb-16">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-6">
           {items.map((integration, index) => (
             <div
               key={index}
@@ -310,15 +310,17 @@ const IntegrationsSection: React.FC = () => {
               </a>
             </div>
           ))}
-          {isMobile && integrations.length > 4 && (
-            <button
-              className="mt-2 text-blue-600 hover:text-blue-700 text-sm font-medium  "
-              onClick={() => setShowAll(!showAll)}
-            >
-              {!showAll ? "View more" : "View less"}
-            </button>
-          )}
         </div>
+        {isMobile && integrations.length > 4 && (
+          <button
+            className="mt-5 mb-11 w-full  text-blue-600 hover:text-blue-700 text-sm font-medium  "
+            onClick={() => setShowAll(!showAll)}
+            aria-expanded={showAll}
+            aria-controls="integrations-grid"
+          >
+            {!showAll ? "View more" : "View less"}
+          </button>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
### Issue Reference

Closes https://github.com/OpsiMate/opsimate-website/issues/50

---

### What Was Changed

- gap between the integration,
- Display top 4 integration by default on Mobile screen 
- Added Viewmore and viewless button for Mobile screen

---


### Screenshots

https://github.com/user-attachments/assets/2b81b4ca-f532-4b93-b833-9c3550962951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrations section is mobile-responsive, showing 4 items by default with a "View more / View less" toggle to expand/collapse the full list.
  * Integration cards now surface icons, refined title/description layout, and a styled "Learn More" link with an external-link indicator.

* **Style**
  * Minor spacing and visual refinements for section headers and card presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->