### PR TITLE
Add LinkedIn button to footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -29,6 +29,11 @@ const Footer: React.FC = () => {
       icon: Github 
     },
     { 
+      name: 'LinkedIn', 
+      href: 'https://www.linkedin.com/company/opsimate/',
+      icon: Linkedin 
+    },
+    { 
       name: 'Slack Community', 
       href: 'https://join.slack.com/t/opsimate/shared_invite/zt-39bq3x6et-NrVCZzH7xuBGIXmOjJM7gA', // From documentation
       icon: Slack 


### PR DESCRIPTION
### Description
Added a LinkedIn button in the website footer that links to OpsiMate’s official LinkedIn page.

### Changes Made
- Added a new LinkedIn entry in the `socialLinks` array inside `Footer.tsx`.
- Used the Lucide `Linkedin` icon for consistent design.
- Ensured the link opens in a new tab (`target="_blank"`) and matches the existing style.
- Verified functionality and visual consistency in both light and dark modes.

### Verification
✅ LinkedIn icon appears next to other social icons in the footer.  
✅ Clicking the icon opens OpsiMate’s LinkedIn page in a new tab.  
✅ No layout or design issues found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LinkedIn social profile link in the footer for easier access to company social presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->