### PR TITLE
feat(ui): Implement responsive 'Show More/Less' toggle for features s…

### DIFF
--- a/components/FeaturesSection.tsx
+++ b/components/FeaturesSection.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import useIsMobile from '../hooks/useIsMobile'; 
 import { 
   Monitor, 
   Bell, 
@@ -10,7 +11,13 @@ import {
 } from 'lucide-react';
 import FeatureCard from './FeatureCard';
 
+const MOBILE_VISIBLE_COUNT = 4; 
+
 const FeaturesSection: React.FC = () => {
+  const isMobile = useIsMobile(); 
+  
+  const [isExpanded, setIsExpanded] = useState(false); 
+
   const features = [
     {
       icon: Monitor,
@@ -54,10 +61,20 @@ const FeaturesSection: React.FC = () => {
     }
   ];
 
+  const featuresToDisplay = 
+      (isMobile && !isExpanded) 
+          ? features.slice(0, MOBILE_VISIBLE_COUNT) 
+          : features; 
+  
+  const handleToggle = () => {
+    setIsExpanded(!isExpanded);
+  };
+  
+  const requiresToggle = isMobile && (features.length > MOBILE_VISIBLE_COUNT);
+
   return (
     <section id="features" className="py-16 features-section">
       <div className="container-max">
-        {/* Section Header */}
         <div className="text-center mb-12">
           <h2 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-surface-100 mb-3">
             Everything You Need to{' '}
@@ -69,9 +86,8 @@ const FeaturesSection: React.FC = () => {
           </p>
         </div>
 
-        {/* Features Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {features.map((feature, index) => (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 md:gap-6"> 
+          {featuresToDisplay.map((feature, index) => ( 
             <FeatureCard
               key={index}
               icon={feature.icon}
@@ -81,6 +97,16 @@ const FeaturesSection: React.FC = () => {
           ))}
         </div>
 
+        {requiresToggle && (
+            <div className="flex justify-center mt-8 md:hidden"> 
+                <button
+                    onClick={handleToggle}
+                    className="py-2 px-6 text-sm font-semibold rounded-lg bg-primary-600 text-white hover:bg-primary-700 transition-colors duration-300"
+                >
+                    {isExpanded ? 'Show Less Features' : 'Show More Features'}
+                </button>
+            </div>
+        )}
 
       </div>
     </section>

--- a/hooks/useIsMobile.ts
+++ b/hooks/useIsMobile.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react';
+
+const useIsMobile = (breakpoint = 768) => {
+  const [isMobile, setIsMobile] = useState(
+      typeof window !== 'undefined' ? window.innerWidth < breakpoint : false
+  );
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+
+    window.addEventListener('resize', checkMobile);
+    checkMobile();
+
+    return () => window.removeEventListener('resize', checkMobile);
+  }, [breakpoint]);
+
+  return isMobile;
+};
+
+export default useIsMobile;


### PR DESCRIPTION
Issue Reference

Closes #[Issue Number]

What Was Changed

This PR introduces responsive behavior to the Features section by implementing a Show More/Show Less toggle on mobile devices.

The changes include:

Creation of a custom useIsMobile React hook to reliably detect screen width.

Conditional rendering in FeaturesSection.tsx to display only the first 4 feature cards by default on screens under 768px (mobile).

Addition of the toggle button functionality using React useState.

Adjustment of the Tailwind gap utility for a more compact mobile layout (gap-4 md:gap-6).

Why Was It Changed

The original Features section displayed all 8 feature cards stacked vertically on mobile, causing the page to feel overloaded and requiring excessive scrolling, which hurts user experience and engagement.

This change improves mobile UX by showing key highlights first, making the section compact and visually balanced without affecting the original desktop layout.

<img width="330" height="712" alt="Screenshot 2025-10-31 at 10 45 37 PM" src="https://github.com/user-attachments/assets/464a6a9c-430d-4a92-9398-e576fc94ffe4" />

<img width="329" height="715" alt="Screenshot 2025-10-31 at 10 46 08 PM" src="https://github.com/user-attachments/assets/e91c5a38-8553-4dd6-888d-9b59409fb679" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile-responsive behavior to the features section with a "Show More/Show Less" button.
  * On mobile devices, the features section now displays a limited set of features initially.
  * Users can expand to view all available features with a toggle button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->