### PR TITLE
[FIX] fixed the Mobile view card of about section misaligned

### DIFF
--- a/components/PersonCard.tsx
+++ b/components/PersonCard.tsx
@@ -26,7 +26,7 @@ const PersonCard: React.FC<PersonCardProps> = ({ contributor: c }) => (
       </div>
       <div className="flex-1">
         <h3 className="font-semibold text-surface-900 dark:text-white">{c.name}</h3>
-        <p className="text-sm text-surface-600 dark:text-surface-400">{c.role}</p>
+        <div className="text-sm text-surface-600 dark:text-surface-400">{c.role}</div>
       </div>
     </div>
 


### PR DESCRIPTION
### Issue Reference

SEE (#75 )
The card in the **About** section appeared **misaligned on mobile view**, while it displayed correctly on desktop view.

---

### What Was Changed

- Replaced the `<p>` tag with a `<div>` tag inside the card component.  
- This adjustment ensures consistent alignment and proper layout behavior across all screen sizes.

---

### Why Was It Changed

Using a `<p>` tag for wrapping elements caused default browser margins and spacing issues, resulting in misalignment on mobile devices.  
Switching to a `<div>` eliminates this issue and keeps the layout responsive and visually consistent.

---

### Screenshots

Before:

[
<img width="264" height="177" alt="508197714-1f947110-9212-42db-ad7b-ed3c57aa8ac7" src="https://github.com/user-attachments/assets/0c94fab8-e8a1-4344-a3b9-54c1e125c781" />
](url)


After:

<img width="513" height="657" alt="image" src="https://github.com/user-attachments/assets/07d665fa-8cde-4ac0-b166-1e6b39706698" />



---

### Additional Context (Optional)

- This fix ensures consistent behavior across different screen breakpoints.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal HTML structure for the contributor card component while maintaining visual appearance and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->