### PR TITLE
chore: migrate links to the opsimate.dev domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">OpsiMate - website repo!</h1>
-<p align="center"><b>The official website of OpsiMate - https://www.opsimate.com/</b></p>
+<p align="center"><b>The official website of OpsiMate - https://www.opsimate.dev/</b></p>
 <p align="center"><b>One console for servers, Docker, and Kubernetes—discover, monitor, and act.</b></p>
 <p align="center">
   Built for DevOps/NOC/IT teams that need a single place to see service health,
@@ -25,9 +25,9 @@
 </p>
 
 <p align="center">
-  <a href="https://opsimate.vercel.app/getting-started/deploy">Get Started</a> ·
-  <a href="https://opsimate.vercel.app/">Docs</a> ·
-  <a href="https://www.opsimate.com/">Website</a> ·
+  <a href="https://docs.opsimate.dev/getting-started/deploy">Get Started</a> ·
+  <a href="https://docs.opsimate.dev/">Docs</a> ·
+  <a href="https://www.opsimate.dev/">Website</a> ·
   <a href="https://github.com/OpsiMate/OpsiMate/issues/new?labels=bug&template=bug_report.md">Report Bug</a>
 </p>
 

--- a/components/CookieComponentBanner.tsx
+++ b/components/CookieComponentBanner.tsx
@@ -51,7 +51,7 @@ const CookieConsentBanner: React.FC = () => {
             are required for the site to function and cannot be turned off. Update your
             preferences any time by selecting the "Privacy Choices" link. By accepting,
             you agree to the OpsiMate{" "}
-            <Link href="https://opsimate.vercel.app/docs/legal/privacy" legacyBehavior>
+            <Link href="https://docs.opsimate.dev/docs/legal/privacy" legacyBehavior>
               <a target="_blank" rel="noopener noreferrer" className="text-[#bbdefb] underline hover:text-[#90caf9] transition-colors duration-200 ease-in-out">
                 Cookie Policy
               </a>

--- a/components/FeatureCard.tsx
+++ b/components/FeatureCard.tsx
@@ -10,7 +10,7 @@ interface FeatureCardProps {
   link?: string;
 }
 
-const DEFAULT_DOCS_URL = 'https://opsimate.vercel.app/docs/';
+const DEFAULT_DOCS_URL = 'https://docs.opsimate.dev/docs/';
 
 const FeatureCard: React.FC<FeatureCardProps> = ({
   icon: Icon,

--- a/components/FeaturesSection.tsx
+++ b/components/FeaturesSection.tsx
@@ -16,49 +16,49 @@ const FeaturesSection: React.FC = () => {
       icon: Bell,
       title: 'Unified Alert Dashboard',
       description: 'Consolidate alerts from all your monitoring tools, cloud providers, and services into one single pane of glass.',
-      link: 'https://opsimate.vercel.app/docs/alerts/adding-alerts',
+      link: 'https://docs.opsimate.dev/docs/alerts/adding-alerts',
     },
     {
       icon: Monitor,
       title: 'Multi-Source Integration',
       description: 'Connect Prometheus, Grafana, Datadog, AWS CloudWatch, and dozens of other alert sources seamlessly.',
-      link: 'https://opsimate.vercel.app/docs/integrations/overview',
+      link: 'https://docs.opsimate.dev/docs/integrations/overview',
     },
     {
       icon: Activity,
       title: 'Real-time Alert Aggregation',
       description: 'See all alerts in real-time with intelligent deduplication and correlation to reduce noise.',
-      link: 'https://opsimate.vercel.app/docs/dashboards/overview',
+      link: 'https://docs.opsimate.dev/docs/dashboards/overview',
     },
     {
       icon: Settings,
       title: 'Smart Alert Routing',
       description: 'Route alerts to the right teams with intelligent filtering, prioritization, and escalation rules.',
-      link: 'https://opsimate.vercel.app/docs/alerts/adding-alerts',
+      link: 'https://docs.opsimate.dev/docs/alerts/adding-alerts',
     },
     {
       icon: Database,
       title: 'Alert History & Analytics',
       description: 'Track alert patterns, response times, and trends to optimize your incident response.',
-      link: 'https://opsimate.vercel.app/docs/dashboards/overview',
+      link: 'https://docs.opsimate.dev/docs/dashboards/overview',
     },
     {
       icon: GitBranch,
       title: 'Automated Response',
       description: 'Trigger automated workflows and remediation actions directly from alerts to resolve issues faster.',
-      link: 'https://opsimate.vercel.app/docs/dashboards/service-menu',
+      link: 'https://docs.opsimate.dev/docs/dashboards/service-menu',
     },
     {
       icon: Server,
       title: 'Infrastructure Visibility',
       description: 'Get complete context for every alert with infrastructure topology and service dependencies.',
-      link: 'https://opsimate.vercel.app/docs/providers-services/overview',
+      link: 'https://docs.opsimate.dev/docs/providers-services/overview',
     },
     {
       icon: GitBranch,
       title: 'Open Source',
       description: 'Fully open source with transparent development. Contribute and customize freely.',
-      link: 'https://opsimate.vercel.app/docs/development',
+      link: 'https://docs.opsimate.dev/docs/development',
     }
   ];
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,7 +12,7 @@ const Footer: React.FC = () => {
       { name: 'Integrations', href: '#integrations' },
     ],
     resources: [
-      { name: 'Documentation', href: 'https://opsimate.vercel.app/#integrations' }, // Placeholder - will link to actual docs
+      { name: 'Documentation', href: 'https://docs.opsimate.dev/#integrations' }, // Placeholder - will link to actual docs
     ],
     opensource: [
       { name: 'GitHub Repository', href: 'https://github.com/OpsiMate/OpsiMate' },

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -35,7 +35,7 @@ const HeroSection: React.FC = () => {
           
             {/* Demo – Highly visible secondary */}
             <a
-              href="https://opsimate.goprosite.net"
+              href="https://demo.opsimate.dev"
               className="relative inline-flex items-center gap-2 text-lg px-8 py-4 rounded-xl
                          border-2 border-blue-600 text-blue-600
                          hover:bg-blue-50 dark:hover:bg-blue-950

--- a/components/IntegrationsSection.tsx
+++ b/components/IntegrationsSection.tsx
@@ -32,7 +32,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-orange-600",
-      link: "https://opsimate.vercel.app/docs/integrations/grafana",
+      link: "https://docs.opsimate.dev/docs/integrations/grafana",
     },
     {
       name: "Kibana",
@@ -59,7 +59,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-purple-600",
-      link: "https://opsimate.vercel.app/docs/integrations/kibana",
+      link: "https://docs.opsimate.dev/docs/integrations/kibana",
     },
     {
       name: "Datadog",
@@ -78,7 +78,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-purple-700",
-      link: "https://opsimate.vercel.app/docs/integrations/datadog",
+      link: "https://docs.opsimate.dev/docs/integrations/datadog",
     },
     {
       name: "Docker",
@@ -177,7 +177,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-blue-500",
-      link: "https://opsimate.vercel.app/docs/providers-services/services/container-services",
+      link: "https://docs.opsimate.dev/docs/providers-services/services/container-services",
     },
     {
       name: "Kubernetes",
@@ -200,7 +200,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-blue-600",
-      link: "https://opsimate.vercel.app/docs/providers-services/services/kubernetes-pods",
+      link: "https://docs.opsimate.dev/docs/providers-services/services/kubernetes-pods",
     },
     {
       name: "Systemd",
@@ -234,7 +234,7 @@ const IntegrationsSection: React.FC = () => {
         </svg>
       ),
       color: "text-blue-600",
-      link: "https://opsimate.vercel.app/docs/providers-services/services/systemd-services",
+      link: "https://docs.opsimate.dev/docs/providers-services/services/systemd-services",
     },
   ];
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -38,7 +38,7 @@ const Layout: React.FC<LayoutProps> = ({
         {/* Additional SEO tags */}
         <meta name="keywords" content="infrastructure management, monitoring, DevOps, cloud management, server monitoring, Kubernetes, Docker, observability" />
         <meta name="author" content="OpsiMate" />
-        <link rel="canonical" href="https://opsimate.com" /> {/* Update with actual domain */}
+        <link rel="canonical" href="https://opsimate.dev" /> {/* Update with actual domain */}
         <link rel="alternate" type="application/rss+xml" title="OpsiMate Blog RSS" href="/feed.xml" />
       </Head>
       

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -39,12 +39,12 @@ const CAL_CONFIG_STRING = JSON.stringify(CAL_CONFIG);
     { name: "Blog", href: "/#blog" },
     {
       name: "Docs",
-      href: "https://opsimate.vercel.app/#integrations",
+      href: "https://docs.opsimate.dev/#integrations",
       external: true,
     },
     {
       name: "Demo",
-      href: "https://opsimate.goprosite.net",
+      href: "https://demo.opsimate.dev",
       external: true,
     },
     { name: "About", href: "/about" },

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -84,7 +84,7 @@ const PrivacyPolicy: React.FC = () => {
               </p>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <p className="text-gray-700">
-                  <strong>Email:</strong> privacy@opsimate.com<br />
+                  <strong>Email:</strong> privacy@opsimate.dev<br />
                   <strong>Address:</strong> OpsiMate Privacy Team<br />
                   789 Business Park Drive, Suite 200<br />
                   San Francisco, CA 94107<br />

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -114,7 +114,7 @@ const TermsOfService: React.FC = () => {
               </p>
               <div className="bg-gray-50 p-4 rounded-lg">
                 <p className="text-gray-700">
-                  <strong>Email:</strong> legal@opsimate.com<br />
+                  <strong>Email:</strong> legal@opsimate.dev<br />
                   <strong>Address:</strong> OpsiMate Legal Team<br />
                   789 Business Park Drive, Suite 200<br />
                   San Francisco, CA 94107<br />


### PR DESCRIPTION
Part of the move to the `opsimate.dev` domain (matches OpsiMate/OpsiMate#677):

- `opsimate.vercel.app/*` → `docs.opsimate.dev/*` (all docs links: navbar, footer, feature cards, integrations, hero, layout, legal pages)
- `opsimate.goprosite.net` → `demo.opsimate.dev` — the live demo now points at the new zero-backend playground sandbox
- `opsimate.com` / `www.opsimate.com` → `opsimate.dev` / `www.opsimate.dev`
- `privacy@`/`legal@opsimate.com` → `@opsimate.dev` (make sure those mailboxes exist on the new domain)

Link/string changes only — the Vercel preview on this PR builds the site for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)