### PR TITLE
chore: SEO foundation — robots.txt, sitemap, structured data

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -22,6 +22,41 @@ const Layout: React.FC<LayoutProps> = ({
         <meta name="description" content={description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
+
+        {/* Structured data so search engines and AI assistants understand what OpsiMate is. */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@graph': [
+                {
+                  '@type': 'Organization',
+                  name: 'OpsiMate',
+                  url: 'https://www.opsimate.dev/',
+                  logo: 'https://www.opsimate.dev/images/og-image.png',
+                  sameAs: [
+                    'https://github.com/OpsiMate/OpsiMate',
+                    'https://docs.opsimate.dev/',
+                    'https://demo.opsimate.dev/',
+                  ],
+                },
+                {
+                  '@type': 'SoftwareApplication',
+                  name: 'OpsiMate',
+                  applicationCategory: 'DeveloperApplication',
+                  operatingSystem: 'Linux, Docker, Kubernetes',
+                  description:
+                    'Open-source platform that centralizes alerts and incidents from Grafana, Prometheus Alertmanager, Datadog, Zabbix, Uptime Kuma and more — with dashboards, on-call schedules, and service management in one place.',
+                  url: 'https://www.opsimate.dev/',
+                  offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+                  softwareHelp: 'https://docs.opsimate.dev/',
+                  installUrl: 'https://docs.opsimate.dev/docs/getting-started/deploy',
+                },
+              ],
+            }),
+          }}
+        />
         
         {/* Open Graph / Facebook */}
         <meta property="og:type" content="website" />

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -70,7 +70,7 @@ export function buildRssXml(params: {
 
 export function getSiteUrl(): string {
   const env = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL;
-  const base = env && env.trim().length > 0 ? env : "http://localhost:3000";
+  const base = env && env.trim().length > 0 ? env : "https://www.opsimate.dev";
   return base.replace(/\/$/, "");
 }
 

--- a/pages/sitemap.xml.ts
+++ b/pages/sitemap.xml.ts
@@ -1,0 +1,30 @@
+import type { GetServerSideProps } from "next";
+import { getAllPublishedPosts } from "@/lib/posts.server";
+import { getSiteUrl } from "@/lib/rss";
+
+const STATIC_PATHS = ["", "/about", "/blog", "/privacy", "/terms"];
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const siteUrl = getSiteUrl();
+  const posts = await getAllPublishedPosts();
+  const urls = [
+    ...STATIC_PATHS.map((p) => `${siteUrl}${p}`),
+    ...posts.map((p) => `${siteUrl}/blog/${p.id}`),
+  ];
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.map((u) => `  <url><loc>${u}</loc></url>`).join("\n")}
+</urlset>
+`;
+
+  res.setHeader("Content-Type", "application/xml; charset=utf-8");
+  res.setHeader("Cache-Control", "s-maxage=1800, stale-while-revalidate=86400");
+  res.write(xml);
+  res.end();
+
+  return { props: {} };
+};
+
+export default function Sitemap() {
+  return null;
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.opsimate.dev/sitemap.xml


### PR DESCRIPTION
Free-visibility groundwork for opsimate.dev:

- **robots.txt** (`public/`) allowing all crawlers — including AI bots (GPTBot, ClaudeBot, Google-Extended fall under `*`) — with a sitemap pointer.
- **/sitemap.xml** — dynamic, mirrors the existing `feed.xml.ts` pattern: static pages + every published blog post.
- **JSON-LD structured data** (Organization + SoftwareApplication) in the shared Layout head: tells Google/Bing/AI assistants OpsiMate is a free developer application, links the GitHub repo, docs, and live demo as `sameAs`.
- `getSiteUrl()` defaults to `https://www.opsimate.dev` instead of localhost so feed/sitemap URLs are correct when `NEXT_PUBLIC_SITE_URL` isn't set.

Verified with a local `next build` — compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)