### PR TITLE
ci: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  # GitHub Actions used across all workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # Node dependencies for the Next.js site
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Batch low-risk minor/patch bumps into one PR to cut noise;
+      # majors still open individually so breaking changes are reviewed.
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Website Docker image
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(docker)"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml`, mirroring the Dependabot setup already running on [OpsiMate/OpsiMate](https://github.com/OpsiMate/OpsiMate/blob/main/.github/dependabot.yml).

## Ecosystems covered

| Ecosystem | Directory | Commit prefix |
|---|---|---|
| `github-actions` | `/` | `ci` |
| `npm` | `/` (Next.js site) | `chore(deps)` |
| `docker` | `/` (root `Dockerfile`) | `ci(docker)` |

All on a **weekly** schedule.

## Noise control

- GitHub Actions bumps are grouped into a single PR.
- npm **minor + patch** bumps are grouped into one PR; **majors open individually** so breaking changes get a proper review.
- PR limit of 10 per ecosystem.

## Differences from the OpsiMate/OpsiMate config

- No `terraform` entry — this repo has no Terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for GitHub Actions, npm packages, and the website’s Docker image.
  * Grouped compatible updates to simplify maintenance while keeping major updates separate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->