### PR TITLE
ci(docker): move to node:24-alpine and pin Dependabot to the LTS line

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,11 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(docker)"
+    ignore:
+      # Node majors alternate LTS/non-LTS and Dependabot only tracks the
+      # newest tag, so it will happily move us onto an odd-numbered release
+      # that is already past end-of-life. Stay on the LTS line and let a
+      # human do the major bump deliberately; patch/minor still flow through.
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  node:22-alpine
+FROM  node:24-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Supersedes #86.

## Why not #86

Dependabot proposed `node:22-alpine` → `node:25-alpine`, and Vercel went green on it. But **Node 25 is already end-of-life.** Odd-numbered Node majors never enter LTS, and 25's window closed on **2026-06-01**. Per [nodejs/Release](https://github.com/nodejs/Release/blob/main/schedule.json):

| Line | LTS | Support ends |
|---|---|---|
| v22 (current image) | yes | 2027-04-30 |
| **v24** | **yes** | **2028-04-30** |
| v25 | never | **2026-06-01 (past)** |
| v26 | yes (from 2026-10-28) | 2029-04-30 |

Dependabot only tracks the newest tag and has no concept of LTS, so this will recur every time a non-LTS major ships.

## What this does

1. `Dockerfile` → `node:24-alpine` (LTS through 2028).
2. Adds an `ignore` rule for **major** bumps of the `node` image in `.github/dependabot.yml`. Patch and minor updates still come through; major LTS-line moves become a deliberate human decision.

Close #86 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Docker runtime to Node.js 24 Alpine.
  * Configured automated Docker updates to allow minor and patch Node.js updates while excluding major version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->