### PR TITLE
ci: add build + typecheck workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and typecheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          # Matches the Dockerfile.
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      # Lint is not a gate yet: `next lint` was silently broken (Next 16
+      # removed it) and the working ESLint setup surfaces pre-existing
+      # errors. Once those are cleaned up, add `npm run lint` here.


### PR DESCRIPTION
## Why

Nothing in CI builds or typechecks this repo. The only checks on a PR are the greeting bot and a Vercel preview *comment* — neither gates anything — and the real Vercel deploy status **isn't a required check**. So a PR can look green while being unbuildable.

That's not hypothetical. Six Dependabot PRs sat open in a broken state (#88, #90, #91, #92, #93, #94) with nothing surfacing it; you had to open the Vercel status by hand to find out. This workflow makes that failure visible on the PR itself.

## What

Runs on every PR and push to `main`:

1. `npm ci`
2. `npx tsc --noEmit`
3. `npm run build`

Node 24, matching the `Dockerfile`. Both steps verified against current `main`.

This is written to keep working across #98 — it calls `npm run build` rather than `next build` directly, so it's unaffected by that PR switching the script to `next build --webpack`.

## Lint is intentionally not a gate yet

`npm run lint` was silently broken — Next 16 removed `next lint`, and it was reading `lint` as a directory name. #98 rewires it to ESLint with a flat config, at which point it reports **17 pre-existing errors** (mostly `react/no-unescaped-entities`, plus new React Compiler rules from `eslint-config-next` 16). None are new code; they've just been invisible.

Adding `npm run lint` here today would land a red main. The right order is: merge #98, clean up the 17 errors, then add the lint step. I've left a comment in the workflow marking the spot.

## Suggestion

Once this is on `main` and has run once, consider making **Build and typecheck** a required status check in branch protection — otherwise it's advisory and the same class of problem can still merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)