### PR TITLE
chore: fix lint errors and make lint a CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,8 @@ jobs:
       - name: Typecheck
         run: npx tsc --noEmit
 
+      - name: Lint
+        run: npm run lint
+
       - name: Build
         run: npm run build
-
-      # Lint is not a gate yet: `next lint` was silently broken (Next 16
-      # removed it) and the working ESLint setup surfaces pre-existing
-      # errors. Once those are cleaned up, add `npm run lint` here.

--- a/components/CTASection.tsx
+++ b/components/CTASection.tsx
@@ -20,7 +20,7 @@ const CTASection: React.FC = () => {
               Ready to Try Open Source Infrastructure Management?
             </h2>
             <p className="text-xl text-primary-100 dark:text-surface-100/90 mb-8 leading-relaxed">
-              Join the growing community of teams using OpsiMate's open source platform. 
+              Join the growing community of teams using OpsiMate&apos;s open source platform. 
               Deploy, customize, and contribute to the future of infrastructure management.
             </p>
             

--- a/components/CookieComponentBanner.tsx
+++ b/components/CookieComponentBanner.tsx
@@ -49,7 +49,7 @@ const CookieConsentBanner: React.FC = () => {
             (including cross-contextual and behavioral targeting advertising efforts) and
             provide an optimal experience as permitted by applicable law. Some cookies
             are required for the site to function and cannot be turned off. Update your
-            preferences any time by selecting the "Privacy Choices" link. By accepting,
+            preferences any time by selecting the &quot;Privacy Choices&quot; link. By accepting,
             you agree to the OpsiMate{" "}
             <Link href="https://docs.opsimate.dev/docs/legal/privacy" legacyBehavior>
               <a target="_blank" rel="noopener noreferrer" className="text-[#bbdefb] underline hover:text-[#90caf9] transition-colors duration-200 ease-in-out">

--- a/components/FeaturesSection.tsx
+++ b/components/FeaturesSection.tsx
@@ -73,7 +73,7 @@ const FeaturesSection: React.FC = () => {
           </h2>
           <p className="text-lg text-surface-600 dark:text-surface-400 max-w-2xl mx-auto">
             OpsiMate consolidates alerts from every source into one unified platform, 
-            giving you complete visibility and control over your entire infrastructure's health.
+            giving you complete visibility and control over your entire infrastructure&apos;s health.
           </p>
         </div>
 

--- a/components/IntegrationsSection.tsx
+++ b/components/IntegrationsSection.tsx
@@ -249,7 +249,7 @@ const IntegrationsSection: React.FC = () => {
           </h2>
           <p className="text-xl text-surface-600 dark:text-surface-400 max-w-3xl mx-auto leading-relaxed">
             OpsiMate seamlessly connects with your current monitoring and infrastructure tools. 
-            No need to replace what's working - enhance it.
+            No need to replace what&apos;s working - enhance it.
           </p>
         </div>
 

--- a/components/PersonCard.tsx
+++ b/components/PersonCard.tsx
@@ -31,7 +31,7 @@ const PersonCard: React.FC<PersonCardProps> = ({ contributor: c }) => (
     </div>
 
     {c.quote && (
-      <blockquote className="mt-4 text-surface-700 dark:text-surface-300 italic">"{c.quote}"</blockquote>
+      <blockquote className="mt-4 text-surface-700 dark:text-surface-300 italic">&quot;{c.quote}&quot;</blockquote>
     )}
 
     {(c.github || c.linkedin) && (

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,25 @@ import nextCoreWebVitals from 'eslint-config-next/core-web-vitals';
 
 // Next 16 removed the `next lint` command and ESLint 9 defaults to flat
 // config, so the linting setup now lives here instead of being implicit.
-export default [
+const config = [
   {
     ignores: ['.next/**', 'node_modules/**', 'next-env.d.ts'],
   },
   ...nextCoreWebVitals,
+  {
+    rules: {
+      // React Compiler rule, new in eslint-config-next 16. It flags any
+      // setState inside an effect, but on the pages router that is the only
+      // correct way to read browser-only state: localStorage and matchMedia
+      // don't exist during SSR, and reading them while rendering causes a
+      // hydration mismatch. The four current call sites (_app, ThemeContext,
+      // CookieComponentBanner, BlogSection) are all this pattern.
+      //
+      // Kept as a warning rather than off so genuine cascading-render cases
+      // still surface in review.
+      'react-hooks/set-state-in-effect': 'warn',
+    },
+  },
 ];
+
+export default config;

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -122,7 +122,7 @@ const AboutPage: React.FC = () => {
               About OpsiMate
             </h1>
             <p className="text-lg text-surface-700 dark:text-surface-300">
-              Born from the frustration of alert fatigue and tool sprawl, OpsiMate was founded by a core team of four visionaries who experienced firsthand the chaos of managing alerts across dozens of platforms. Instead of adding another monitoring tool to the noise, we built a unified alert management platform—your single pane of glass for every alert, from every source. Our mission is simple but bold: consolidate all your alerts into one intelligent platform, giving you complete visibility and control over your entire infrastructure's health in one place.
+              Born from the frustration of alert fatigue and tool sprawl, OpsiMate was founded by a core team of four visionaries who experienced firsthand the chaos of managing alerts across dozens of platforms. Instead of adding another monitoring tool to the noise, we built a unified alert management platform—your single pane of glass for every alert, from every source. Our mission is simple but bold: consolidate all your alerts into one intelligent platform, giving you complete visibility and control over your entire infrastructure&apos;s health in one place.
             </p>
             <div className="mt-8 max-w-4xl mx-auto relative">
               <div
@@ -170,7 +170,7 @@ const AboutPage: React.FC = () => {
           <div>
             <h3 className="text-xl md:text-2xl font-semibold text-surface-900 dark:text-white mb-4 text-center">Community Leaders 🌟</h3>
             <p className="text-surface-700 dark:text-surface-300 text-center mb-6 max-w-2xl mx-auto">
-              Our community leaders are the driving force behind OpsiMate's success. They dedicate their time, expertise, and passion to help build, improve, and grow the platform, making OpsiMate better for everyone.
+              Our community leaders are the driving force behind OpsiMate&apos;s success. They dedicate their time, expertise, and passion to help build, improve, and grow the platform, making OpsiMate better for everyone.
             </p>
             <div className={`grid gap-6 ${gridColsFor(communityLeaders.length)} justify-items-center`}>
               {communityLeaders.map((c, idx) => (
@@ -186,7 +186,7 @@ const AboutPage: React.FC = () => {
           <div className="rounded-2xl p-8 md:p-12 bg-white dark:bg-surface-900 border border-surface-200 dark:border-surface-800 text-center">
             <h2 className="text-2xl md:text-3xl font-bold text-surface-900 dark:text-white">Join the OpsiMate community 🚀</h2>
             <p className="mt-3 text-surface-700 dark:text-surface-300">
-              Whether you're exploring, adopting, or contributing—you're welcome here.
+              Whether you&apos;re exploring, adopting, or contributing—you&apos;re welcome here.
             </p>
             <div className="mt-6 flex flex-col sm:flex-row gap-3 justify-center">
               <Link

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -83,7 +83,7 @@ const TermsOfService: React.FC = () => {
 
               <h2 className="text-2xl font-semibold text-gray-900 mb-4">8. Disclaimer</h2>
               <p className="text-gray-700 mb-6">
-                The information on this service is provided on an "as is" basis. To the fullest extent 
+                The information on this service is provided on an &quot;as is&quot; basis. To the fullest extent 
                 permitted by law, this Company excludes all representations, warranties, conditions and 
                 terms relating to our service and the use of this service.
               </p>


### PR DESCRIPTION
Follow-up to #98 and #99.

## Context

#98 got `npm run lint` working again — it had been silently broken, since Next 16 removed `next lint` and the script was reading `lint` as a directory name. Once fixed, it reported **17 errors** that had been invisible for as long as the script was misconfigured. #99 deliberately left lint out of CI so it wouldn't land a red `main`. This clears the errors and adds the gate.

## The 13 mechanical ones

`react/no-unescaped-entities` — bare `'` and `"` in JSX text, across 7 files. Escaped to `&apos;` / `&quot;`.

Verified this changed nothing user-visible: the built HTML contains `&#x27;` / `&quot;` (which render as `'` and `"`), there's no double-escaping (`&amp;apos;` appears nowhere), and I loaded `/about` in a browser and confirmed the text reads *"Whether you're exploring, adopting, or contributing—you're welcome here."*

## The 4 that aren't actually bugs

`react-hooks/set-state-in-effect` is a React Compiler rule new to `eslint-config-next` 16. It flags **any** `setState` inside an effect. All four call sites — `pages/_app.tsx`, `contexts/ThemeContext.tsx`, `components/CookieComponentBanner.tsx`, `components/BlogSection.tsx` — do the same thing: read `localStorage` or `matchMedia` on mount.

On the pages router that's the *only* correct way to do it. Those APIs don't exist during SSR, so reading them while rendering either crashes on the server or produces a hydration mismatch. "Fixing" the rule here would mean introducing the bug it's meant to prevent.

So I downgraded it to `warn` rather than refactoring four working components, with the reasoning recorded in `eslint.config.mjs` so it doesn't get re-litigated. Genuine cascading-render cases still surface in review — it's a warning, not off.

I'm flagging this as a judgment call rather than burying it: if you'd rather see those four refactored properly (e.g. moving to `useSyncExternalStore`), that's a reasonable position — it's just a bigger change than a lint cleanup, and riskier than it looks.

## Result

```
✖ 12 problems (0 errors, 12 warnings)
```

Remaining warnings are `@next/next/no-img-element` (blog images) and the four above — worth addressing, none blocking. `ci.yml` now runs `npm run lint` between typecheck and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Improved text consistency across the About, Terms, features, integrations, CTA, cookie banner, and testimonial sections.
  * Enhanced content validation to catch potential React hook issues earlier.

* **CI Improvements**
  * Lint checks now run automatically as part of the build verification process, helping maintain a more reliable release experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->