### PR TITLE
chore(deps): bump typescript to 6.0.3 and modernise target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "rehype-stringify": "^10.0.0",
         "remark-rehype": "^11.1.0",
         "tailwindcss": "^3.3.0",
-        "typescript": "^5.2.0"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7865,9 +7865,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "rehype-stringify": "^10.0.0",
     "remark-rehype": "^11.1.0",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5.2.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES2017",
     "lib": ["dom", "dom.iterable", "es6"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Replaces #92.

## Why not TypeScript 7

Dependabot keeps proposing TS 7. It doesn't work here — Next 16 rejects it outright:

```
TypeScript 7.0.2 does not provide the compiler API required by Next.js.
Enable experimental.useTypeScriptCli in your Next.js config to use the
TypeScript CLI, or install TypeScript 6 instead.
```

TS 7 is the native Go rewrite and doesn't expose the compiler API Next drives. Getting it working means enabling an experimental Next flag — not a reasonable trade for a routine dep bump. Next itself points at TS 6, which is what this does.

## Also: target=ES5

TS 6 deprecates `target: es5` (TS5107), and this `tsconfig.json` still set it — a leftover that's been irrelevant for years given the browsers Next 16 and React 19 support anyway.

Moved to `ES2017` rather than silencing it with `ignoreDeprecations`, since the deprecation is correct and papering over it just defers the same work to TS 7.

## Verification

- `tsc --noEmit` clean
- `npm run lint` unchanged at 0 errors, 12 warnings
- `npm run build` passes
- `/`, `/about`, `/blog`, `/terms` all serve 200 under `next start`

Close #92 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)