### PR TITLE
fix(docker): install from the lockfile with npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ WORKDIR /app
 
 COPY ./package*.json  ./
 
-RUN npm install
+# npm ci, not npm install: install from the lockfile so the image gets the
+# same versions CI tested. `npm install` re-resolves the semver ranges in
+# package.json, so the image can silently drift from the lockfile as new
+# releases ship.
+RUN npm ci
 
 COPY . .
 


### PR DESCRIPTION
Small hygiene fix — `npm install` → `npm ci` in the `Dockerfile`.

## Why

`npm install` re-resolves the semver ranges in `package.json` instead of honouring `package-lock.json`. The image can therefore ship different dependency versions than CI tested, and drift further every time an upstream minor lands. Since this image runs `npm run dev`, that drift reaches whoever is developing in the container — the person least likely to suspect their dependencies differ from everyone else's.

`npm ci` installs exactly what the lockfile pins, which is what CI and Vercel test.

## Scope

**This is preventive, not a bug fix** — I checked, and the versions currently line up (`next` resolves to 16.2.12 either way). Flagging that so it's clear this isn't fixing an active break.

It's worth doing because the docs repo had the same class of problem — image installing from a different source than CI — and nobody noticed until the Docker build failed outright (OpsiMate/documentation#118). This is the cheap version of that fix, applied before it bites.

## Verification

Built and ran the image: builds clean, installs `next` 16.2.12 matching the lockfile, serves 200 on `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker builds by using the lockfile for consistent dependency installation.
  * Added documentation clarifying the installation process and version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->